### PR TITLE
Remove webpack4 manual tag from react-ssr-setup project

### DIFF
--- a/data/source/react-starter-projects.js
+++ b/data/source/react-starter-projects.js
@@ -385,7 +385,7 @@ module.exports = {
     },
     {
       url: "https://github.com/manuelbieh/react-ssr-setup",
-      tags: ["css modules", "webpack4"],
+      tags: ["css modules"],
     },
   ],
 };


### PR DESCRIPTION
`webpack 4` tag is added automatically and this causes the project to be the only one that has `webpack4` tag.