### PR TITLE
Update developer239/ReactReduxApolloGraphQLHotBoilerplate link

### DIFF
--- a/data/source/react-starter-projects.js
+++ b/data/source/react-starter-projects.js
@@ -142,7 +142,7 @@ module.exports = {
     { url: "https://github.com/davezuko/react-redux-starter-kit" },
     {
       url:
-        "https://github.com/developer239/ReactReduxApolloGraphQLHotBoilerplate",
+        "https://github.com/developer239/react-redux-apollo-graphql",
     },
     { url: "https://github.com/developer239/workbox-webpack-react" },
     { url: "https://github.com/diegohaz/arc" },


### PR DESCRIPTION
Now redirects to https://github.com/developer239/react-redux-apollo-graphql

This was found as part of link checking the webpack documentation with https://www.npmjs.com/package/hyperlink