### PR TITLE
Add minimal starter for Webpack + React

### DIFF
--- a/data/source/react-starter-projects.js
+++ b/data/source/react-starter-projects.js
@@ -407,5 +407,9 @@ module.exports = {
         "https://github.com/alishahlakhani/Reactsx-React-TS-SCSS-PWA-Boilerplate",
       tags: ["css modules"],
     },
+    {
+      url: "https://github.com/rwieruch/minimal-react-webpack-babel-setup",
+      tags: ["tutorial"],
+    },
   ],
 };


### PR DESCRIPTION
I used this starter project to teach people React with Webpack 2, 3 and 4. Looking forward to update it soonish to Webpack 5. It's a minimal setup of using React + Webpack + Babel + HMR. and can be read up as tutorial over [here](https://www.robinwieruch.de/minimal-react-webpack-babel-setup/). Would be great to include it in the list of Webpack Starter Projects :)