### PR TITLE
Add about reenode in react starter projects

### DIFF
--- a/data/source/react-starter-projects.js
+++ b/data/source/react-starter-projects.js
@@ -407,5 +407,8 @@ module.exports = {
         "https://github.com/alishahlakhani/Reactsx-React-TS-SCSS-PWA-Boilerplate",
       tags: ["css modules"],
     },
+    {
+      url: "https://github.com/praveen-me/reenode",
+    },
   ],
 };


### PR DESCRIPTION
I added about `reenode`. A CLI for generating boilerplates using node and react.